### PR TITLE
Re-enabled CA after switch to .NET 5

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -99,6 +99,11 @@ dotnet_diagnostic.CA1040.severity = none
 #   no plan to translate the application into other languages.
 dotnet_diagnostic.CA1303.severity = error
 
+# CA1308: Normalize strings to uppercase
+# Reason: In almost all cases this rule is irrelevant - and just causes noise. (I've yet to see an example of the problem
+#   this rule is supposed to prevent.)
+dotnet_diagnostic.CA1308.severity = none
+
 # CA1707: Identifiers should not contain underscores
 # Reason: Our style guide uses underscores for constants.
 dotnet_diagnostic.CA1707.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -108,6 +108,12 @@ dotnet_diagnostic.CA1707.severity = none
 #   developers who know what they're doing and explicitly want to name a certain type that way).
 dotnet_diagnostic.CA1711.severity = none
 
+# CA1716: Identifiers should not match keywords
+# Reason: I've yet to encounter a problem caused by violating this rule. At the moment, I don't know
+#   and can't think of any. So we'll leave this rule disabled until we find some case where it's really
+#   useful.
+dotnet_diagnostic.CA1716.severity = none
+
 # CA1717: Only FlagsAttribute enums should have plural names
 # Reason: That's a matter of preference. On the other hand, allowing plural enum name resolves name conflicts if
 #   the enum is a nested enum and there's a property for that enum in the outer class.

--- a/.editorconfig
+++ b/.editorconfig
@@ -103,6 +103,11 @@ dotnet_diagnostic.CA1303.severity = error
 # Reason: Our style guide uses underscores for constants.
 dotnet_diagnostic.CA1707.severity = none
 
+# CA1711: Identifiers should not have incorrect suffix
+# Reason: While it may be useful in general, it just produces too many false positives (especially for
+#   developers who know what they're doing and explicitly want to name a certain type that way).
+dotnet_diagnostic.CA1711.severity = none
+
 # CA1717: Only FlagsAttribute enums should have plural names
 # Reason: That's a matter of preference. On the other hand, allowing plural enum name resolves name conflicts if
 #   the enum is a nested enum and there's a property for that enum in the outer class.

--- a/AppMotor.CliApp/AppMotor.CliApp.csproj
+++ b/AppMotor.CliApp/AppMotor.CliApp.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>net5.0</TargetFramework>
 
     <!-- See also: https://docs.microsoft.com/en-us/nuget/create-packages/prerelease-packages -->
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
 
     <!--
       Unfortunately, System.CommandLine is still pre-release; so we have to ignore this warning.

--- a/AppMotor.CliApp/CliApplication.cs
+++ b/AppMotor.CliApp/CliApplication.cs
@@ -107,7 +107,7 @@ namespace AppMotor.CliApp
                 app.Terminal = terminal;
             }
 
-            return await app.RunAsync(args);
+            return await app.RunAsync(args).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace AppMotor.CliApp
 
             try
             {
-                exitCode = await this.MainExecutor.Execute(args);
+                exitCode = await this.MainExecutor.Execute(args).ConfigureAwait(continueOnCapturedContext: false);
             }
             catch (Exception exception) when (!Debugger.IsAttached)
             {

--- a/AppMotor.CliApp/CliApplicationExecutor.cs
+++ b/AppMotor.CliApp/CliApplicationExecutor.cs
@@ -132,7 +132,7 @@ namespace AppMotor.CliApp
         {
             this.m_action = async _ =>
             {
-                await action();
+                await action().ConfigureAwait(continueOnCapturedContext: false);
                 return 0;
             };
         }
@@ -147,7 +147,7 @@ namespace AppMotor.CliApp
         {
             this.m_action = async args =>
             {
-                await action(args);
+                await action(args).ConfigureAwait(continueOnCapturedContext: false);
                 return 0;
             };
         }
@@ -185,7 +185,7 @@ namespace AppMotor.CliApp
         {
             this.m_action = async _ =>
             {
-                bool retVal = await action();
+                bool retVal = await action().ConfigureAwait(continueOnCapturedContext: false);
                 return retVal ? 0 : 1;
             };
         }
@@ -201,7 +201,7 @@ namespace AppMotor.CliApp
         {
             this.m_action = async args =>
             {
-                bool retVal = await action(args);
+                bool retVal = await action(args).ConfigureAwait(continueOnCapturedContext: false);
                 return retVal ? 0 : 1;
             };
         }
@@ -211,7 +211,7 @@ namespace AppMotor.CliApp
         /// </summary>
         public async Task<int> Execute(string[] args)
         {
-            return await this.m_action(args);
+            return await this.m_action(args).ConfigureAwait(continueOnCapturedContext: false);
         }
     }
 }

--- a/AppMotor.CliApp/CommandLine/CliApplicationWithCommands.cs
+++ b/AppMotor.CliApp/CommandLine/CliApplicationWithCommands.cs
@@ -61,7 +61,8 @@ namespace AppMotor.CliApp.CommandLine
             return await rootCommand.InvokeAsync(
                 SortHelpFirst(args),
                 new CommandLineConsole(this.Terminal)
-            );
+            )
+            .ConfigureAwait(continueOnCapturedContext: false);
         }
 
         /// <summary>

--- a/AppMotor.CliApp/CommandLine/CliApplicationWithoutCommands.cs
+++ b/AppMotor.CliApp/CommandLine/CliApplicationWithoutCommands.cs
@@ -72,7 +72,7 @@ namespace AppMotor.CliApp.CommandLine
 
             rootCommand.Handler = new CliCommandHandler(this);
 
-            return await rootCommand.InvokeAsync(args, new CommandLineConsole(this.Terminal));
+            return await rootCommand.InvokeAsync(args, new CommandLineConsole(this.Terminal)).ConfigureAwait(continueOnCapturedContext: false);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace AppMotor.CliApp.CommandLine
             {
                 this.m_app.SetAllParamValues(context.ParseResult);
 
-                return await this.m_app.Executor.Execute();
+                return await this.m_app.Executor.Execute().ConfigureAwait(continueOnCapturedContext: false);
             }
         }
     }

--- a/AppMotor.CliApp/CommandLine/CliCommand.cs
+++ b/AppMotor.CliApp/CommandLine/CliCommand.cs
@@ -61,7 +61,7 @@ namespace AppMotor.CliApp.CommandLine
         /// <returns>The exit code for the running program.</returns>
         private async Task<int> Execute()
         {
-            return await this.Executor.Execute();
+            return await this.Executor.Execute().ConfigureAwait(continueOnCapturedContext: false);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace AppMotor.CliApp.CommandLine
             {
                 this.m_command.SetAllParamValues(context.ParseResult);
 
-                return await this.m_command.Execute();
+                return await this.m_command.Execute().ConfigureAwait(continueOnCapturedContext: false);
             }
         }
     }

--- a/AppMotor.CliApp/CommandLine/CliCommandExecutor.cs
+++ b/AppMotor.CliApp/CommandLine/CliCommandExecutor.cs
@@ -86,7 +86,7 @@ namespace AppMotor.CliApp.CommandLine
         {
             this.m_action = async () =>
             {
-                await action();
+                await action().ConfigureAwait(continueOnCapturedContext: false);
                 return 0;
             };
         }
@@ -113,7 +113,7 @@ namespace AppMotor.CliApp.CommandLine
         {
             this.m_action = async () =>
             {
-                bool retVal = await action();
+                bool retVal = await action().ConfigureAwait(continueOnCapturedContext: false);
                 return retVal ? 0 : 1;
             };
         }
@@ -123,7 +123,7 @@ namespace AppMotor.CliApp.CommandLine
         /// </summary>
         public async Task<int> Execute()
         {
-            return await this.m_action();
+            return await this.m_action().ConfigureAwait(continueOnCapturedContext: false);
         }
     }
 }

--- a/AppMotor.CliApp/CommandLine/CliVerb.cs
+++ b/AppMotor.CliApp/CommandLine/CliVerb.cs
@@ -19,6 +19,7 @@ using System.Collections.Immutable;
 using System.CommandLine;
 
 using AppMotor.CliApp.CommandLine.Utils;
+using AppMotor.Core.Utils;
 
 using JetBrains.Annotations;
 
@@ -60,6 +61,7 @@ namespace AppMotor.CliApp.CommandLine
         protected CliVerb(string name, string[] aliases)
         {
             ValidateCommandName(name);
+            Validate.Argument.IsNotNull(aliases, nameof(aliases));
 
             foreach (var alias in aliases)
             {
@@ -74,6 +76,8 @@ namespace AppMotor.CliApp.CommandLine
 
         private static void ValidateCommandName(string name)
         {
+            Validate.Argument.IsNotNull(name, nameof(name));
+
             if (HelpParamUtils.IsHelpParamName(name) || name.Equals(HelpParamUtils.HelpCommandName, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException($"The name '{name}' is reserved and can't be used.", nameof(name));

--- a/AppMotor.CliApp/CommandLine/CliVerbGroup.cs
+++ b/AppMotor.CliApp/CommandLine/CliVerbGroup.cs
@@ -42,6 +42,7 @@ namespace AppMotor.CliApp.CommandLine
         /// verb group.
         /// </summary>
         [PublicAPI]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Potentially expensive execution")]
         protected abstract IEnumerable<CliVerb> GetSubVerbs();
 
         internal sealed override Command ToUnderlyingImplementation()

--- a/AppMotor.CliApp/CommandLine/Utils/CliParamUtils.cs
+++ b/AppMotor.CliApp/CommandLine/Utils/CliParamUtils.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 using System.Reflection;
 
 using AppMotor.Core.Extensions;
+using AppMotor.Core.Utils;
 
 using JetBrains.Annotations;
 
@@ -37,8 +38,12 @@ namespace AppMotor.CliApp.CommandLine.Utils
         /// </summary>
         /// <param name="container">The object that holds the parameters.</param>
         [MustUseReturnValue]
+#pragma warning disable CA1002 // Do not expose generic lists // BUG: https://github.com/dotnet/roslyn-analyzers/issues/4508
         public static List<CliParam> GetAllParamsFor(object container)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
+            Validate.Argument.IsNotNull(container, nameof(container));
+
             var allParams = new List<CliParam>();
             var alreadyFoundCliParams = new HashSet<CliParam>(ReferenceEqualityComparer.Instance);
             var allParamNames = new HashSet<string>();
@@ -137,7 +142,7 @@ namespace AppMotor.CliApp.CommandLine.Utils
         /// </summary>
         private sealed class ParamComparer : IComparer<CliParam>
         {
-            public static readonly ParamComparer INSTANCE = new ParamComparer();
+            public static readonly ParamComparer INSTANCE = new();
 
             /// <inheritdoc />
             public int Compare(CliParam? x, CliParam? y)

--- a/AppMotor.CliApp/CommandLine/Utils/HelpParamUtils.cs
+++ b/AppMotor.CliApp/CommandLine/Utils/HelpParamUtils.cs
@@ -14,6 +14,8 @@
 // limitations under the License.
 #endregion
 
+using AppMotor.Core.Utils;
+
 using JetBrains.Annotations;
 
 namespace AppMotor.CliApp.CommandLine.Utils
@@ -39,6 +41,8 @@ namespace AppMotor.CliApp.CommandLine.Utils
         [MustUseReturnValue]
         public static bool IsHelpParamName(string arg)
         {
+            Validate.Argument.IsNotNull(arg, nameof(arg));
+
             switch (arg.ToLowerInvariant())
             {
                 case "-h":

--- a/AppMotor.Core/AppMotor.Core.csproj
+++ b/AppMotor.Core/AppMotor.Core.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>net5.0</TargetFramework>
 
     <!-- See also: https://docs.microsoft.com/en-us/nuget/create-packages/prerelease-packages -->
-    <Version>0.9.0</Version>
+    <Version>0.9.1</Version>
   </PropertyGroup>
 
   <!--

--- a/AppMotor.Core/DataModel/Optional.cs
+++ b/AppMotor.Core/DataModel/Optional.cs
@@ -121,7 +121,9 @@ namespace AppMotor.Core.DataModel
         {
             if (this.IsSet)
             {
+#pragma warning disable CA1508 // Avoid dead conditional code // BUG: https://github.com/dotnet/roslyn-analyzers/issues/4509
                 return this.m_value?.ToString() ?? "";
+#pragma warning restore CA1508 // Avoid dead conditional code
             }
             else
             {

--- a/AppMotor.Core/DataModel/Optional.cs
+++ b/AppMotor.Core/DataModel/Optional.cs
@@ -15,6 +15,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 
 using JetBrains.Annotations;
 
@@ -28,7 +29,7 @@ namespace AppMotor.Core.DataModel
     /// is set or not.
     /// </para>
     /// </summary>
-    public readonly struct Optional<T>
+    public readonly struct Optional<T> : IEquatable<Optional<T>>
     {
         /// <summary>
         /// You may use this to unset an optional value.
@@ -75,6 +76,44 @@ namespace AppMotor.Core.DataModel
         public static implicit operator Optional<T>(T value)
         {
             return new(value);
+        }
+
+        /// <inheritdoc />
+        public bool Equals(Optional<T> other)
+        {
+            if (this.IsSet != other.IsSet)
+            {
+                return false;
+            }
+
+            if (!this.IsSet) // && !other.IsSet
+            {
+                return true;
+            }
+
+            return EqualityComparer<T>.Default.Equals(this.m_value, other.m_value);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            return obj is Optional<T> other && Equals(other);
+        }
+
+        public static bool operator ==(Optional<T> left, Optional<T> right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Optional<T> left, Optional<T> right)
+        {
+            return !(left == right);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.m_value, this.IsSet);
         }
 
         /// <inheritdoc />

--- a/AppMotor.Core/Exceptions/ICollectionIsReadOnlyException.cs
+++ b/AppMotor.Core/Exceptions/ICollectionIsReadOnlyException.cs
@@ -1,12 +1,12 @@
 ﻿#region License
 // Copyright 2020 AppMotor Framework (https://github.com/skrysmanski/AppMotor)
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/AppMotor.Core/Extensions/CollectionExtensions.cs
+++ b/AppMotor.Core/Extensions/CollectionExtensions.cs
@@ -53,7 +53,9 @@ namespace AppMotor.Core.Extensions
         /// removed, the returned list will be empty (but never <c>null</c>).</returns>
         /// <exception cref="CollectionIsReadOnlyException">Thrown if the collection is read-only.</exception>
         [PublicAPI]
+#pragma warning disable CA1002 // Do not expose generic lists // BUG: https://github.com/dotnet/roslyn-analyzers/issues/4508
         public static List<T> RemoveWhere<T>(this ICollection<T> collection, Predicate<T> predicate)
+#pragma warning restore CA1002 // Do not expose generic lists
         {
             Validate.Argument.IsNotNull(collection, nameof(collection));
             Validate.Argument.IsNotNull(predicate, nameof(predicate));

--- a/AppMotor.Core/Processes/ChildProcess.cs
+++ b/AppMotor.Core/Processes/ChildProcess.cs
@@ -284,12 +284,12 @@ namespace AppMotor.Core.Processes
                 }
                 catch (Win32Exception ex) when (ex.NativeErrorCode == 2) // Could not find file.
                 {
-                    throw new Exception($"Could not locate application file at: {this.m_process.StartInfo.FileName}");
+                    throw new InvalidOperationException($"Could not locate application file at: {this.m_process.StartInfo.FileName}");
                 }
 
                 if (!startSuccessful)
                 {
-                    throw new Exception("Process could not be started for unknown reasons.");
+                    throw new InvalidOperationException("Process could not be started for unknown reasons.");
                 }
 
                 stdOutReadTask = Task.Run(() => this.m_process.StandardOutput.ReadToEndAsync());

--- a/AppMotor.Core/Utils/AsyncDisposable.cs
+++ b/AppMotor.Core/Utils/AsyncDisposable.cs
@@ -38,10 +38,7 @@ namespace AppMotor.Core.Utils
 
                     DisposeUnmanagedResources();
 
-                    // BUG: This is a false-positive; see: https://github.com/dotnet/roslyn-analyzers/issues/3675
-#pragma warning disable CA1816 // Dispose methods should call SuppressFinalize
                     GC.SuppressFinalize(this);
-#pragma warning restore CA1816 // Dispose methods should call SuppressFinalize
                 }
                 catch (Exception)
                 {

--- a/AppMotor.Core/Utils/TlsSettings.cs
+++ b/AppMotor.Core/Utils/TlsSettings.cs
@@ -34,8 +34,10 @@ namespace AppMotor.Core.Utils
             // NOTE: The default value of "ServicePointManager.SecurityProtocol" depends on the .NET Framework
             //   being used. This is why this method makes sure the value is the same across all frameworks.
 
+#pragma warning disable CA5386 // Avoid hardcoding SecurityProtocolType value -> we don't want the OS to select outdated TLS versions
             EnableProtocol(SecurityProtocolType.Tls13); // TLS 1.3
             EnableProtocol(SecurityProtocolType.Tls12); // TLS 1.2
+#pragma warning restore CA5386 // Avoid hardcoding SecurityProtocolType value
 
 #pragma warning disable CA5364 // Do Not Use Deprecated Security Protocols
             // NOTE: TLS 1.0 and 1.1 are considered obsolete/outdated nowadays and are disabled on more and more

--- a/COMMON/CommonAssemblyInfo.cs
+++ b/COMMON/CommonAssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+// Mark this assembly as "CLS compliant".
+// Details: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/CA1014
+//
+// NOTE: This can't be done in a .csproj file at the moment: https://github.com/dotnet/msbuild/issues/2281
+[assembly: CLSCompliant(true)]

--- a/Project.Code.props
+++ b/Project.Code.props
@@ -27,6 +27,11 @@
     <InternalsVisibleTo Include="$(MSBuildProjectName).Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Shared assembly attributes that can't be set via .props file. -->
+    <Compile Include="$(MSBuildThisFileDirectory)COMMON\CommonAssemblyInfo.cs" Link="Properties\CommonAssemblyInfo.cs" />
+  </ItemGroup>
+
   <!--
     .NET static code analysis
 

--- a/Project.Code.props
+++ b/Project.Code.props
@@ -27,4 +27,17 @@
     <InternalsVisibleTo Include="$(MSBuildProjectName).Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+      Provides Microsoft's/.NET's static code analyzers.
+
+      NOTE: While - since .NET 5 - the code analyzers ship with the .NET SDK, the shipped
+        version will only update when the SDK itself updates (which - on Windows - usually means
+        an update of Visual Studio). With this NuGet package reference we have full control
+        over the version that's being used (and can upgrade faster than the SDK, if necessary).
+        See: https://github.com/dotnet/roslyn-analyzers/issues/4506
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1" PrivateAssets="all" />
+  </ItemGroup>
+
 </Project>

--- a/Project.Code.props
+++ b/Project.Code.props
@@ -27,6 +27,19 @@
     <InternalsVisibleTo Include="$(MSBuildProjectName).Tests" />
   </ItemGroup>
 
+  <!--
+    .NET static code analysis
+
+    See: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview
+  -->
+  <PropertyGroup Label="Code Analysis">
+    <!--
+      Enable all CA rules by default. Otherwise only a small subset will be enabled by default.
+      See: https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#analysismode
+    -->
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+  </PropertyGroup>
+
   <ItemGroup>
     <!--
       Provides Microsoft's/.NET's static code analyzers.


### PR DESCRIPTION
With .NET 5, most CA rules were disabled by default and thus didn't trigger. This pull requests re-enables all rules and fixes the resulting errors.