### PR TITLE
Implement stricter naming rules for parameters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -102,6 +102,11 @@ dotnet_diagnostic.CA1303.severity = error
 #   this rule is supposed to prevent.)
 dotnet_diagnostic.CA1308.severity = none
 
+# CA1700: Do not name enum values 'Reserved'
+# Reason: Left over from old "worst-pratice" implementations. We don't do this. If left enabled it
+#   prevents naming an enum member "ReservedName", even though this is a valid name.
+dotnet_diagnostic.CA1700.severity = none
+
 # CA1707: Identifiers should not contain underscores
 # Reason: Our style guide uses underscores for constants.
 dotnet_diagnostic.CA1707.severity = none

--- a/src/AppMotor.CliApp/CommandLine/CliParam.cs
+++ b/src/AppMotor.CliApp/CommandLine/CliParam.cs
@@ -21,6 +21,7 @@ using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Linq;
 
+using AppMotor.CliApp.CommandLine.Utils;
 using AppMotor.Core.DataModel;
 using AppMotor.Core.Exceptions;
 using AppMotor.Core.Extensions;
@@ -93,9 +94,11 @@ namespace AppMotor.CliApp.CommandLine
         /// <summary>
         /// Creates a named parameter (in contrast to a positional one). See <see cref="CliParamTypes.Named"/> for more details.
         /// </summary>
-        /// <param name="primaryName">The primary name for this parameter; must start with either "--" or "-".</param>
+        /// <param name="primaryName">The primary name for this parameter; must be a valid named parameter name (i.e. start with
+        /// either "--" or "-") - see <see cref="CliParamNameValidation.CheckIfNameIsValid"/> for more details.</param>
         /// <param name="aliases">Other names that represent the same parameter. Usually the <paramref name="primaryName"/>
-        /// would be the long form (like <c>--length</c>) and the alias(es) would be the short form (like <c>-l</c>).</param>
+        /// would be the long form (like <c>--length</c>) and the alias(es) would be the short form (like <c>-l</c>);
+        /// must be valid named parameter names.</param>
         public CliParam(string primaryName, params string[] aliases)
             : this(ParamsUtils.Combine(primaryName, aliases))
         {
@@ -107,7 +110,8 @@ namespace AppMotor.CliApp.CommandLine
         /// <para>Note: You should prefer the other constructor (<see cref="CliParam{T}(string,string[])"/>) over this
         /// one.</para>
         /// </summary>
-        /// <param name="names">The names/aliases for this parameter; must start with either "--" or "-".</param>
+        /// <param name="names">The names/aliases for this parameter; must be a valid named parameter name (i.e. start with
+        /// either "--" or "-") - see <see cref="CliParamNameValidation.CheckIfNameIsValid"/> for more details.</param>
         public CliParam(IEnumerable<string> names)
             : base(names)
         {
@@ -122,7 +126,8 @@ namespace AppMotor.CliApp.CommandLine
         /// <summary>
         /// Creates a positional parameter (in contrast to a named parameter). See <see cref="CliParamTypes.Positional"/> for more details.
         /// </summary>
-        /// <param name="name">The name of this parameter; only used for generating the help text.</param>
+        /// <param name="name">The name of this parameter; only used for generating the help text; must be a valid positional
+        /// parameter name - see <see cref="CliParamNameValidation.CheckIfNameIsValid"/> for more details.</param>
         /// <param name="positionIndex">The position of this parameter among all other positional parameters; positional parameters
         /// are ordered by this value</param>
         public CliParam(string name, int positionIndex)

--- a/src/AppMotor.CliApp/CommandLine/CliParam.cs
+++ b/src/AppMotor.CliApp/CommandLine/CliParam.cs
@@ -93,8 +93,7 @@ namespace AppMotor.CliApp.CommandLine
         /// <summary>
         /// Creates a named parameter (in contrast to a positional one). See <see cref="CliParamTypes.Named"/> for more details.
         /// </summary>
-        /// <param name="primaryName">The primary name for this parameter; for better documentation purposes this
-        /// should start with either "--", "-" or "/".</param>
+        /// <param name="primaryName">The primary name for this parameter; must start with either "--" or "-".</param>
         /// <param name="aliases">Other names that represent the same parameter. Usually the <paramref name="primaryName"/>
         /// would be the long form (like <c>--length</c>) and the alias(es) would be the short form (like <c>-l</c>).</param>
         public CliParam(string primaryName, params string[] aliases)
@@ -108,8 +107,7 @@ namespace AppMotor.CliApp.CommandLine
         /// <para>Note: You should prefer the other constructor (<see cref="CliParam{T}(string,string[])"/>) over this
         /// one.</para>
         /// </summary>
-        /// <param name="names">The names/aliases for this parameter; for better documentation purposes these
-        /// should start with either "--", "-" or "/".</param>
+        /// <param name="names">The names/aliases for this parameter; must start with either "--" or "-".</param>
         public CliParam(IEnumerable<string> names)
             : base(names)
         {

--- a/src/AppMotor.CliApp/CommandLine/CliParamBase.cs
+++ b/src/AppMotor.CliApp/CommandLine/CliParamBase.cs
@@ -113,11 +113,6 @@ namespace AppMotor.CliApp.CommandLine
 
                 Validate.ValueWithName(nameof(name)).IsValidParameterName(name, CliParamTypes.Named);
 
-                if (HelpParamUtils.IsHelpParamName(name))
-                {
-                    throw new ArgumentException($"The name '{name}' is reserved and can't be used.", nameof(names));
-                }
-
                 namesSet.Add(name);
             }
 
@@ -133,11 +128,6 @@ namespace AppMotor.CliApp.CommandLine
         protected CliParamBase(string name, int positionIndex)
         {
             Validate.ArgumentWithName(nameof(name)).IsValidParameterName(name, CliParamTypes.Positional);
-
-            if (HelpParamUtils.IsHelpParamName(name))
-            {
-                throw new ArgumentException($"The name '{name}' is reserved and can't be used.", nameof(name));
-            }
 
             this.Names = new[] { name }.ToImmutableArray();
             this.PositionIndex = positionIndex;

--- a/src/AppMotor.CliApp/CommandLine/CliParamBase.cs
+++ b/src/AppMotor.CliApp/CommandLine/CliParamBase.cs
@@ -85,7 +85,8 @@ namespace AppMotor.CliApp.CommandLine
         /// <summary>
         /// Creates a named parameter (in contrast to a positional one). See <see cref="CliParamTypes.Named"/> for more details.
         /// </summary>
-        /// <param name="names">The names/aliases for this parameter; must start with either "--" or "-".</param>
+        /// <param name="names">The names/aliases for this parameter; must be a valid named parameter name (i.e. start with
+        /// either "--" or "-") - see <see cref="CliParamNameValidation.CheckIfNameIsValid"/> for more details.</param>
         protected CliParamBase(IEnumerable<string> names)
         {
             var allNames = names.ToImmutableArray();
@@ -123,7 +124,8 @@ namespace AppMotor.CliApp.CommandLine
         /// <summary>
         /// Creates a positional parameter (in contrast to a named parameter). See <see cref="CliParamTypes.Positional"/> for more details.
         /// </summary>
-        /// <param name="name">The name of this parameter; only used for generating the help text.</param>
+        /// <param name="name">The name of this parameter; only used for generating the help text; must be a valid positional
+        /// parameter name - see <see cref="CliParamNameValidation.CheckIfNameIsValid"/> for more details.</param>
         /// <param name="positionIndex">The position of this parameter among all other positional parameters; positional parameters
         /// are ordered by this value</param>
         protected CliParamBase(string name, int positionIndex)

--- a/src/AppMotor.CliApp/CommandLine/CliParamBase.cs
+++ b/src/AppMotor.CliApp/CommandLine/CliParamBase.cs
@@ -85,8 +85,7 @@ namespace AppMotor.CliApp.CommandLine
         /// <summary>
         /// Creates a named parameter (in contrast to a positional one). See <see cref="CliParamTypes.Named"/> for more details.
         /// </summary>
-        /// <param name="names">The names/aliases for this parameter; for better documentation purposes these
-        /// should start with either "--", "-" or "/".</param>
+        /// <param name="names">The names/aliases for this parameter; must start with either "--" or "-".</param>
         protected CliParamBase(IEnumerable<string> names)
         {
             var allNames = names.ToImmutableArray();
@@ -112,6 +111,8 @@ namespace AppMotor.CliApp.CommandLine
                     throw new ArgumentException($"Passing the same name ('{name}') multiple times is not allowed.", nameof(names));
                 }
 
+                Validate.ValueWithName(nameof(name)).IsValidParameterName(name, CliParamTypes.Named);
+
                 if (HelpParamUtils.IsHelpParamName(name))
                 {
                     throw new ArgumentException($"The name '{name}' is reserved and can't be used.", nameof(names));
@@ -131,7 +132,7 @@ namespace AppMotor.CliApp.CommandLine
         /// are ordered by this value</param>
         protected CliParamBase(string name, int positionIndex)
         {
-            Validate.ArgumentWithName(nameof(name)).IsNotNullOrWhiteSpace(name);
+            Validate.ArgumentWithName(nameof(name)).IsValidParameterName(name, CliParamTypes.Positional);
 
             if (HelpParamUtils.IsHelpParamName(name))
             {

--- a/src/AppMotor.CliApp/CommandLine/CliParamBase.cs
+++ b/src/AppMotor.CliApp/CommandLine/CliParamBase.cs
@@ -111,7 +111,8 @@ namespace AppMotor.CliApp.CommandLine
                     throw new ArgumentException($"Passing the same name ('{name}') multiple times is not allowed.", nameof(names));
                 }
 
-                Validate.ValueWithName(nameof(name)).IsValidParameterName(name, CliParamTypes.Named);
+                // NOTE: We want "ArgumentExceptions" here for "names" - not "ValueExceptions" for "name".
+                Validate.ArgumentWithName(nameof(names)).IsValidParameterName(name, CliParamTypes.Named);
 
                 namesSet.Add(name);
             }

--- a/src/AppMotor.CliApp/CommandLine/Utils/CliParamNameValidation.cs
+++ b/src/AppMotor.CliApp/CommandLine/Utils/CliParamNameValidation.cs
@@ -25,8 +25,15 @@ using NotNullOnExitAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 
 namespace AppMotor.CliApp.CommandLine.Utils
 {
+    /// <summary>
+    /// Provides validation methods for parameter names (as used in <see cref="CliParam{T}"/>).
+    /// </summary>
     public static class CliParamNameValidation
     {
+        /// <summary>
+        /// Validation method to be used with <see cref="Validate"/>. See <see cref="CheckIfNameIsValid"/> for more details.
+        /// </summary>
+        [PublicAPI]
         public static void IsValidParameterName(this NamedValidator validator, [NotNullOnExit] string? paramName, CliParamTypes paramType, bool allowReservedParamName = false)
         {
             validator.IsNotNullOrWhiteSpace(paramName);
@@ -60,11 +67,20 @@ namespace AppMotor.CliApp.CommandLine.Utils
             }
         }
 
+        /// <summary>
+        /// Checks if the given parameter name (<paramref name="paramName"/>) is a valid parameter name for the given parameter
+        /// type (<paramref name="paramType"/>) and returns the result. See <see cref="CliParamNameValidityCheckResults"/> for
+        /// details on name rules.
+        /// </summary>
+        /// <param name="paramName">The name to check</param>
+        /// <param name="paramType">The parameter type this name is to be used for.</param>
+        /// <param name="allowReservedParamName">Whether reserved names are allowed for <paramref name="paramName"/>. Is <c>false</c>
+        /// by default.</param>
+        /// <returns>The result of the check.</returns>
+        /// <seealso cref="IsValidParameterName"/>
         [PublicAPI, MustUseReturnValue]
         public static CliParamNameValidityCheckResults CheckIfNameIsValid(string paramName, CliParamTypes paramType, bool allowReservedParamName = false)
         {
-            Validate.ArgumentWithName(nameof(paramName)).IsNotNull(paramName);
-
             if (string.IsNullOrWhiteSpace(paramName))
             {
                 return CliParamNameValidityCheckResults.Invalid;
@@ -126,16 +142,54 @@ namespace AppMotor.CliApp.CommandLine.Utils
 
             return CliParamNameValidityCheckResults.Valid;
         }
-
-
     }
 
+    /// <summary>
+    /// The result of <see cref="CliParamNameValidation.CheckIfNameIsValid"/>. See each enum member
+    /// for details on the rules.
+    /// </summary>
     public enum CliParamNameValidityCheckResults
     {
+        /// <summary>
+        /// The name is valid.
+        /// </summary>
         Valid,
-        Invalid,
+
+        /// <summary>
+        /// The name contains spaces which is not allowed.
+        /// </summary>
         ContainsSpaces,
+
+        /// <summary>
+        /// The name is a reserved name that must not be used.
+        /// </summary>
         ReservedName,
+
+        /// <summary>
+        /// The name is invalid for some other reason. The primary problems are:
+        ///
+        /// <list type="bullet">
+        /// <item>
+        /// <description>The name is null or empty or just white space characters.</description>
+        /// </item>
+        /// <item>
+        /// <description>The name is for a named parameter and does not start with the "-" or "--" prefix.</description>
+        /// </item>
+        /// <item>
+        /// <description>The name is for a named parameter, stats with a single "-" but has more than one character after that.
+        /// For example, allowed are <c>-m</c>, <c>-t</c> but not <c>-abc</c>.</description>
+        /// </item>
+        /// <item>
+        /// <description>The name is for a named parameter, stats with "--" but only has one character after that.
+        /// For example, allowed are <c>--my-value</c>, <c>--temp</c> but not <c>--a</c>.</description>
+        /// </item>
+        /// <item>
+        /// <description>The name is for a positional parameter but stats with "-" or "/". Names for positional
+        /// parameters must not have a prefix.</description>
+        /// </item>
+        /// </list>
+        /// </summary>
+        Invalid,
     }
 
 }

--- a/src/AppMotor.CliApp/CommandLine/Utils/CliParamNameValidation.cs
+++ b/src/AppMotor.CliApp/CommandLine/Utils/CliParamNameValidation.cs
@@ -176,20 +176,19 @@ namespace AppMotor.CliApp.CommandLine.Utils
         /// <description>The name is for a named parameter and does not start with the "-" or "--" prefix.</description>
         /// </item>
         /// <item>
-        /// <description>The name is for a named parameter, stats with a single "-" but has more than one character after that.
+        /// <description>The name is for a named parameter, starts with a single "-" but has more than one character after that.
         /// For example, allowed are <c>-m</c>, <c>-t</c> but not <c>-abc</c>.</description>
         /// </item>
         /// <item>
-        /// <description>The name is for a named parameter, stats with "--" but only has one character after that.
+        /// <description>The name is for a named parameter, starts with "--" but only has one character after that.
         /// For example, allowed are <c>--my-value</c>, <c>--temp</c> but not <c>--a</c>.</description>
         /// </item>
         /// <item>
-        /// <description>The name is for a positional parameter but stats with "-" or "/". Names for positional
+        /// <description>The name is for a positional parameter but starts with "-" or "/". Names for positional
         /// parameters must not have a prefix.</description>
         /// </item>
         /// </list>
         /// </summary>
         Invalid,
     }
-
 }

--- a/src/AppMotor.CliApp/CommandLine/Utils/CliParamNameValidation.cs
+++ b/src/AppMotor.CliApp/CommandLine/Utils/CliParamNameValidation.cs
@@ -1,0 +1,132 @@
+﻿#region License
+// Copyright 2021 AppMotor Framework (https://github.com/skrysmanski/AppMotor)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+
+using AppMotor.Core.Exceptions;
+using AppMotor.Core.Utils;
+
+using JetBrains.Annotations;
+
+using NotNullOnExitAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
+
+namespace AppMotor.CliApp.CommandLine.Utils
+{
+    public static class CliParamNameValidation
+    {
+        public static void IsValidParameterName(this NamedValidator validator, [NotNullOnExit] string? value, CliParamTypes paramType)
+        {
+            validator.IsNotNullOrWhiteSpace(value);
+
+            var checkResult = CheckIfNameIsValid(value, paramType);
+
+            switch (checkResult)
+            {
+                case CliParamNameValidityCheckResults.Valid:
+                    // ok
+                    break;
+
+                case CliParamNameValidityCheckResults.Invalid:
+                    if (paramType == CliParamTypes.Named)
+                    {
+                        throw validator.CreateRootException($"The parameter name '{value}' is invalid. Names of named parameters must either be '-x' or '--some-name'.");
+                    }
+                    else
+                    {
+                        throw validator.CreateRootException($"The parameter name '{value}' is invalid. Names of positional parameters must not start with a prefix.");
+                    }
+
+                case CliParamNameValidityCheckResults.ContainsSpaces:
+                    throw validator.CreateRootException($"The parameter name '{value}' is invalid because it contains spaces.");
+
+                default:
+                    throw new UnexpectedSwitchValueException(nameof(checkResult), checkResult);
+            }
+        }
+
+        [PublicAPI, MustUseReturnValue]
+        public static CliParamNameValidityCheckResults CheckIfNameIsValid(string value, CliParamTypes paramType)
+        {
+            Validate.ArgumentWithName(nameof(value)).IsNotNull(value);
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return CliParamNameValidityCheckResults.Invalid;
+            }
+
+            if (paramType == CliParamTypes.Named)
+            {
+                char firstCharAfterPrefix;
+
+                if (value.Length == 2)
+                {
+                    if (!value.StartsWith('-'))
+                    {
+                        return CliParamNameValidityCheckResults.Invalid;
+                    }
+
+                    firstCharAfterPrefix = value[1];
+                }
+                else if (value.Length >= 4)
+                {
+                    if (!value.StartsWith("--", StringComparison.Ordinal))
+                    {
+                        return CliParamNameValidityCheckResults.Invalid;
+                    }
+
+                    firstCharAfterPrefix = value[2];
+                }
+                else
+                {
+                    return CliParamNameValidityCheckResults.Invalid;
+                }
+
+                if (firstCharAfterPrefix == '-')
+                {
+                    return CliParamNameValidityCheckResults.Invalid;
+                }
+            }
+            else
+            {
+                var firstChar = value[0];
+
+                switch (firstChar)
+                {
+                    case '-':
+                    case '/':
+                        return CliParamNameValidityCheckResults.Invalid;
+                }
+            }
+
+            if (value.Contains(' ', StringComparison.Ordinal))
+            {
+                return CliParamNameValidityCheckResults.ContainsSpaces;
+            }
+
+            return CliParamNameValidityCheckResults.Valid;
+        }
+
+
+    }
+
+    public enum CliParamNameValidityCheckResults
+    {
+        Valid,
+        Invalid,
+        ContainsSpaces,
+    }
+
+}

--- a/src/AppMotor.CliApp/CommandLine/Utils/CliParamNameValidation.cs
+++ b/src/AppMotor.CliApp/CommandLine/Utils/CliParamNameValidation.cs
@@ -79,7 +79,7 @@ namespace AppMotor.CliApp.CommandLine.Utils
         /// <returns>The result of the check.</returns>
         /// <seealso cref="IsValidParameterName"/>
         [PublicAPI, MustUseReturnValue]
-        public static CliParamNameValidityCheckResults CheckIfNameIsValid(string paramName, CliParamTypes paramType, bool allowReservedParamName = false)
+        public static CliParamNameValidityCheckResults CheckIfNameIsValid(string? paramName, CliParamTypes paramType, bool allowReservedParamName = false)
         {
             if (string.IsNullOrWhiteSpace(paramName))
             {

--- a/tests/AppMotor.CliApp.Tests/Tests/CommandLine/CliParamUtilsTests.cs
+++ b/tests/AppMotor.CliApp.Tests/Tests/CommandLine/CliParamUtilsTests.cs
@@ -56,8 +56,8 @@ namespace AppMotor.CliApp.Tests.CommandLine
                 allParamsAsDict.ShouldContainKey(GetBaseParamName(visibility, Scopes.Instance, MemberTypes.Property));
             }
 
-            allParamsAsDict.ShouldContainKey("instance_property_param_with_backing_field");
-            allParamsAsDict.ShouldContainKey("instance_property_param_with_backing_field_base");
+            allParamsAsDict.ShouldContainKey("--instance_property_param_with_backing_field");
+            allParamsAsDict.ShouldContainKey("--instance_property_param_with_backing_field_base");
         }
 
         [Fact]
@@ -107,13 +107,13 @@ namespace AppMotor.CliApp.Tests.CommandLine
         [MustUseReturnValue]
         private static string GetParamName(Visibilities visibility, Scopes scope, MemberTypes memberType)
         {
-            return $"{visibility}_{scope}_{memberType}_param";
+            return $"--{visibility}_{scope}_{memberType}_param";
         }
 
         [MustUseReturnValue]
         private static string GetBaseParamName(Visibilities visibility, Scopes scope, MemberTypes memberType)
         {
-            return $"{visibility}_{scope}_{memberType}_base_param";
+            return $"--{visibility}_{scope}_{memberType}_base_param";
         }
 
         private class TestContainer : TestContainerBase
@@ -175,7 +175,7 @@ namespace AppMotor.CliApp.Tests.CommandLine
 
 
 
-            private readonly CliParam<string> _propertyParamWithBackingField = new("instance_property_param_with_backing_field");
+            private readonly CliParam<string> _propertyParamWithBackingField = new("--instance_property_param_with_backing_field");
 
             /// <summary>
             /// This parameter must only occur once.
@@ -250,7 +250,7 @@ namespace AppMotor.CliApp.Tests.CommandLine
 
 
 
-            private readonly CliParam<string> _propertyParamWithBackingBaseField = new("instance_property_param_with_backing_field_base");
+            private readonly CliParam<string> _propertyParamWithBackingBaseField = new("--instance_property_param_with_backing_field_base");
 
             /// <summary>
             /// This parameter must only occur once.
@@ -292,10 +292,10 @@ namespace AppMotor.CliApp.Tests.CommandLine
         private sealed class TestContainerWithDoubleParamNames
         {
             [UsedImplicitly]
-            public CliParam<string> Param1 { get; } = new("a_param_name");
+            public CliParam<string> Param1 { get; } = new("--a_param_name");
 
             [UsedImplicitly]
-            public CliParam<string> Param2 { get; } = new("a_param_name"); // same name as param1
+            public CliParam<string> Param2 { get; } = new("--a_param_name"); // same name as param1
         }
 
         private sealed class TestContainerWithPositionalParams

--- a/tests/AppMotor.CliApp.Tests/Tests/CommandLine/Utils/CliParamNameValidationTests.cs
+++ b/tests/AppMotor.CliApp.Tests/Tests/CommandLine/Utils/CliParamNameValidationTests.cs
@@ -1,0 +1,180 @@
+﻿#region License
+// Copyright 2021 AppMotor Framework (https://github.com/skrysmanski/AppMotor)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System.Collections.Generic;
+
+using AppMotor.CliApp.CommandLine;
+using AppMotor.CliApp.CommandLine.Utils;
+using AppMotor.Core.Exceptions;
+using AppMotor.Core.Utils;
+
+using Shouldly;
+
+using Xunit;
+
+namespace AppMotor.CliApp.Tests.CommandLine.Utils
+{
+    public sealed class CliParamNameValidationTests
+    {
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void Test_CheckIfNameIsValid(string? paramName, CliParamTypes paramType, bool allowReservedParamName, CliParamNameValidityCheckResults expectedResult)
+        {
+            CliParamNameValidation.CheckIfNameIsValid(paramName, paramType, allowReservedParamName: allowReservedParamName).ShouldBe(expectedResult);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public void Test_IsValidParameterName(string? paramName, CliParamTypes paramType, bool allowReservedParamName, CliParamNameValidityCheckResults expectedResult)
+        {
+            if (expectedResult == CliParamNameValidityCheckResults.Valid)
+            {
+                Should.NotThrow(() => Validate.ValueWithName("abc").IsValidParameterName(paramName, paramType, allowReservedParamName: allowReservedParamName));
+            }
+            else
+            {
+                var ex = Should.Throw<ValueException>(() => Validate.ValueWithName("abc").IsValidParameterName(paramName, paramType, allowReservedParamName: allowReservedParamName));
+                if (string.IsNullOrWhiteSpace(paramName))
+                {
+                    var emptyStringException = Should.Throw<ValueException>(() => Validate.ValueWithName("abc").IsNotNullOrWhiteSpace(paramName));
+                    ex.Message.ShouldBe(emptyStringException.Message);
+                }
+                else
+                {
+                    switch (expectedResult)
+                    {
+                        case CliParamNameValidityCheckResults.Invalid:
+                            if (paramType == CliParamTypes.Named)
+                            {
+                                ex.Message.ShouldStartWith($"The parameter name '{paramName}' is invalid. Names of named parameters must either be '-x' or '--some-name'.");
+                            }
+                            else
+                            {
+                                ex.Message.ShouldStartWith($"The parameter name '{paramName}' is invalid. Names of positional parameters must not start with a prefix.");
+                            }
+                            break;
+
+                        case CliParamNameValidityCheckResults.ContainsSpaces:
+                            ex.Message.ShouldStartWith($"The parameter name '{paramName}' is invalid because it contains spaces.");
+                            break;
+
+                        case CliParamNameValidityCheckResults.ReservedName:
+                            ex.Message.ShouldStartWith($"The name '{paramName}' is reserved and can't be used.");
+                            break;
+
+                        default:
+                            throw new UnexpectedSwitchValueException(nameof(expectedResult), expectedResult);
+                    }
+                }
+
+            }
+        }
+
+        public static IEnumerable<object?[]> TestData
+        {
+            get
+            {
+                foreach (var enumerable in UnflattedTestData)
+                {
+                    foreach (var testData in enumerable)
+                    {
+                        yield return testData;
+                    }
+                }
+            }
+        }
+
+        // ReSharper disable once IdentifierTypo
+        private static IEnumerable<IEnumerable<object?[]>> UnflattedTestData
+        {
+            get
+            {
+                yield return CreateTestDataWith(paramName: null, paramType: null, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.Invalid);
+                yield return CreateTestDataWith(paramName: "", paramType: null, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.Invalid);
+                yield return CreateTestDataWith(paramName: "  ", paramType: null, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.Invalid);
+
+                yield return CreateTestDataWith(paramName: "-h", paramType: CliParamTypes.Named, allowReservedParamName: false, expectedResult: CliParamNameValidityCheckResults.ReservedName);
+                yield return CreateTestDataWith(paramName: "--help", paramType: CliParamTypes.Named, allowReservedParamName: false, expectedResult: CliParamNameValidityCheckResults.ReservedName);
+                yield return CreateTestDataWith(paramName: "help", paramType: CliParamTypes.Positional, allowReservedParamName: false, expectedResult: CliParamNameValidityCheckResults.Valid); // this is indeed valid
+                yield return CreateTestDataWith(paramName: "-h", paramType: CliParamTypes.Named, allowReservedParamName: true, expectedResult: CliParamNameValidityCheckResults.Valid);
+                yield return CreateTestDataWith(paramName: "--help", paramType: CliParamTypes.Named, allowReservedParamName: true, expectedResult: CliParamNameValidityCheckResults.Valid);
+                yield return CreateTestDataWith(paramName: "help", paramType: CliParamTypes.Positional, allowReservedParamName: true, expectedResult: CliParamNameValidityCheckResults.Valid);
+
+                yield return CreateTestDataWith(paramName: "-abc", paramType: CliParamTypes.Named, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.Invalid);
+                yield return CreateTestDataWith(paramName: "--a", paramType: CliParamTypes.Named, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.Invalid);
+                yield return CreateTestDataWith(paramName: "-a", paramType: CliParamTypes.Named, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.Valid);
+                yield return CreateTestDataWith(paramName: "--abc", paramType: CliParamTypes.Named, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.Valid);
+
+                yield return CreateTestDataWith(paramName: "--", paramType: CliParamTypes.Named, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.Invalid);
+                yield return CreateTestDataWith(paramName: "-", paramType: CliParamTypes.Named, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.Invalid);
+
+                yield return CreateTestDataWith(paramName: "-- a", paramType: CliParamTypes.Named, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.ContainsSpaces);
+                yield return CreateTestDataWith(paramName: "- ", paramType: CliParamTypes.Named, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.ContainsSpaces);
+                yield return CreateTestDataWith(paramName: "a b", paramType: CliParamTypes.Positional, allowReservedParamName: null, expectedResult: CliParamNameValidityCheckResults.ContainsSpaces);
+            }
+        }
+
+        private static IEnumerable<object?[]> CreateTestDataWith(string? paramName, CliParamTypes? paramType, bool? allowReservedParamName, CliParamNameValidityCheckResults expectedResult)
+        {
+            if (paramType is null)
+            {
+                foreach (var testData in CreateTestDataWith(paramName, CliParamTypes.Named, allowReservedParamName, expectedResult))
+                {
+                    yield return testData;
+                }
+                foreach (var testData in CreateTestDataWith(paramName, CliParamTypes.Positional, allowReservedParamName, expectedResult))
+                {
+                    yield return testData;
+                }
+            }
+            else
+            {
+                foreach (var testData in CreateTestDataWith(paramName, paramType.Value, allowReservedParamName, expectedResult))
+                {
+                    yield return testData;
+                }
+            }
+        }
+
+        private static IEnumerable<object?[]> CreateTestDataWith(string? paramName, CliParamTypes paramType, bool? allowReservedParamName, CliParamNameValidityCheckResults expectedResult)
+        {
+            if (allowReservedParamName is null)
+            {
+                foreach (var testData in CreateTestDataWith(paramName, paramType, allowReservedParamName: true, expectedResult))
+                {
+                    yield return testData;
+                }
+
+                foreach (var testData in CreateTestDataWith(paramName, paramType, allowReservedParamName: false, expectedResult))
+                {
+                    yield return testData;
+                }
+            }
+            else
+            {
+                foreach (var testData in CreateTestDataWith(paramName, paramType, allowReservedParamName.Value, expectedResult))
+                {
+                    yield return testData;
+                }
+            }
+        }
+
+        private static IEnumerable<object?[]> CreateTestDataWith(string? paramName, CliParamTypes paramType, bool allowReservedParamName, CliParamNameValidityCheckResults expectedResult)
+        {
+            yield return new object?[] { paramName, paramType, allowReservedParamName, expectedResult };
+        }
+    }
+}


### PR DESCRIPTION
It's currently rather unclear what names a parameter can have (i.e. with or without prefix, which prefixes) and whether parameters with different prefixes are the same (e.g. is `/myvalue` the same as `--myvalue` if the parameter name is `--myvalue` or just `myvalue`). This pull requests answers these questions by restricting what names can be chosen.