### PR TITLE
Improve CI.yaml for scheduled execution

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,8 +66,17 @@ jobs:
         # run this step even if previous step failed
         if: success() || failure()
         with:
-          # See: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
-          # run_id is something like 1152888876
+          # NOTE: To make the downloads of the test results easier to use (i.e. when downloading test results
+          #   from different runs), we'll add an id to the name.
+          #
+          #   We don't use the sha because this workflow also runs on a schedule - which means that different
+          #   runs would again create files with the same name (e.g. two consecutive scheduled runs while the
+          #   repo hasn't changed in the meantime).
+          #
+          #   Instead we use 'github.run_number' because this gives us the same number that's also shown in the
+          #   ui - like 27 for run #27 ('github.run_id' on the other hand gives us some "random" big number like
+          #   1152888876 - which is less useful). For more details, see:
+          #   https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
           name: test-results-${{ github.run_number }}
           path: '**/*.trx'
           if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,12 +38,6 @@ jobs:
           lfs: true
           submodules: true
 
-      # This creates ${{ steps.short-sha.outputs.sha }} to be used below.
-      - name: Determine Git short commit hash
-        # See: https://github.com/marketplace/actions/short-sha
-        uses: benjlevesque/short-sha@56c9032868f85fc82058ff0793e58ab97bb2b856
-        id: short-sha
-
       - name: Setup .NET build environment
         # See: https://github.com/actions/setup-dotnet
         uses: actions/setup-dotnet@v1
@@ -72,6 +66,6 @@ jobs:
         # run this step even if previous step failed
         if: success() || failure()
         with:
-          name: test-results-${{ steps.short-sha.outputs.sha }}
+          name: test-results-${{ github.run_id }}
           path: '**/*.trx'
           if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,8 @@ jobs:
         # run this step even if previous step failed
         if: success() || failure()
         with:
-          name: test-results-${{ github.run_id }}
+          # See: https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
+          # run_id is something like 1152888876
+          name: test-results-${{ github.run_number }}
           path: '**/*.trx'
           if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,12 @@ jobs:
           lfs: true
           submodules: true
 
+      # This creates ${{ steps.short-sha.outputs.sha }} to be used below.
+      - name: Determine Git short commit hash
+        # See: https://github.com/marketplace/actions/short-sha
+        uses: benjlevesque/short-sha@56c9032868f85fc82058ff0793e58ab97bb2b856
+        id: short-sha
+
       - name: Setup .NET build environment
         # See: https://github.com/actions/setup-dotnet
         uses: actions/setup-dotnet@v1
@@ -69,7 +75,7 @@ jobs:
           # NOTE: To make the downloads of the test results easier to use (i.e. when downloading test results
           #   from different runs), we'll add an id to the name.
           #
-          #   We don't use the sha because this workflow also runs on a schedule - which means that different
+          #   We don't just use the sha because this workflow also runs on a schedule - which means that different
           #   runs would again create files with the same name (e.g. two consecutive scheduled runs while the
           #   repo hasn't changed in the meantime).
           #
@@ -77,6 +83,6 @@ jobs:
           #   ui - like 27 for run #27 ('github.run_id' on the other hand gives us some "random" big number like
           #   1152888876 - which is less useful). For more details, see:
           #   https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context
-          name: test-results-${{ github.run_number }}
+          name: test-results-${{ steps.short-sha.outputs.sha }}-#${{ github.run_number }}
           path: '**/*.trx'
           if-no-files-found: error


### PR DESCRIPTION
Different (scheduled) runs on an unchanged repo (i.e. same HEAD sha) will now produce differently name test result artifacts on every run.